### PR TITLE
Update node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "broccoli-caching-writer": "^0.5.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.0.0-pre"
+    "node-sass": "^3.0.0-alpha.0"
   }
 }


### PR DESCRIPTION
This newer version has no changes, but does has prebuilt binaries, which makes installing the node-sass package much faster.